### PR TITLE
Fix cant delete threads

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "crypto": "^1.0.1",
     "dotenv": "^6.1.0",
     "express": "^4.16.4",
+    "lodash": "^4.17.11",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "slackbots": "^1.1.0"

--- a/utils.js
+++ b/utils.js
@@ -161,7 +161,7 @@ const utils = {
     try {
       let threadedMsg = {};
       try {
-        threadedMsg = await utils.reportDuplicateInChannelAsThread(channelId, originalMsg, copyMsg, userId, linkToOriginalMsg, linkToCopyMsg);
+        // threadedMsg = await utils.reportDuplicateInChannelAsThread(channelId, originalMsg, copyMsg, userId, linkToOriginalMsg, linkToCopyMsg);
       } catch (error) {
         threadedMsg = {};
       }

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const crypto = require('crypto');
 const dotenv = require('dotenv');
 const request = require('request-promise-native');
@@ -158,7 +159,12 @@ const utils = {
     const linkToOriginalMsg = await utils.getMessagePermalink(originalMsg, channelId);
     const linkToCopyMsg = await utils.getMessagePermalink(copyMsg, channelId);
     try {
-      const threadedMsg = await utils.reportDuplicateInChannelAsThread(channelId, originalMsg, copyMsg, userId, linkToOriginalMsg, linkToCopyMsg);
+      let threadedMsg = {};
+      try {
+        threadedMsg = await utils.reportDuplicateInChannelAsThread(channelId, originalMsg, copyMsg, userId, linkToOriginalMsg, linkToCopyMsg);
+      } catch (error) {
+        threadedMsg = {};
+      }
       await utils.reportDuplicateInChannelAsEphemeral(channelId, originalMsg, copyMsg, userId, linkToOriginalMsg, linkToCopyMsg, threadedMsg);
     } catch (error) {
       await utils.reportDuplicateToUser(channelId, originalMsg, copyMsg, userId, linkToOriginalMsg, linkToCopyMsg);
@@ -186,7 +192,10 @@ const utils = {
             text: 'Delete Copy',
             style: 'danger',
             type: 'button',
-            value: JSON.stringify({ message_ts: copyMsg.ts, threaded_message_ts: threadedMsg.ts })
+            value: JSON.stringify({
+              message_ts: copyMsg.ts,
+              threaded_message_ts: !(_.isEmpty(threadedMsg)) ? threadedMsg.ts : null
+            })
           }]
         }]
       }


### PR DESCRIPTION
For some reasons on some workspaces the bot can't delete its own replies to duplicate messages.

This PR is to stop the bot from posting such replies for now.